### PR TITLE
internal/ethapi: add GetTransactionReceiptsByBlockNumber

### DIFF
--- a/ethclient/ethclient.go
+++ b/ethclient/ethclient.go
@@ -280,6 +280,16 @@ func (ec *Client) TransactionInBlock(ctx context.Context, blockHash common.Hash,
 	return json.tx, err
 }
 
+// TransactionRecipientsInBlock returns a single transaction at index in the given block.
+func (ec *Client) TransactionRecipientsInBlock(ctx context.Context, number *big.Int) ([]*types.Receipt, error) {
+	var rs []*types.Receipt
+	err := ec.c.CallContext(ctx, &rs, "eth_getTransactionReceiptsByBlockNumber", toBlockNumArg(number))
+	if err != nil {
+		return nil, err
+	}
+	return rs, err
+}
+
 // TransactionReceipt returns the receipt of a transaction by transaction hash.
 // Note that the receipt is not available for pending transactions.
 func (ec *Client) TransactionReceipt(ctx context.Context, txHash common.Hash) (*types.Receipt, error) {

--- a/internal/jsre/deps/web3.js
+++ b/internal/jsre/deps/web3.js
@@ -5368,6 +5368,13 @@ var methods = function () {
         outputFormatter: formatters.outputTransactionReceiptFormatter
     });
 
+    var getTransactionReceiptsByBlockNumber = new Method({
+      name: 'getTransactionReceiptsByBlockNumber',
+      call: 'eth_getTransactionReceiptsByBlockNumber',
+      params: 1,
+      outputFormatter: formatters.outputTransactionReceiptFormatter
+    });
+
     var getTransactionCount = new Method({
         name: 'getTransactionCount',
         call: 'eth_getTransactionCount',
@@ -5461,6 +5468,7 @@ var methods = function () {
         getTransaction,
         getTransactionFromBlock,
         getTransactionReceipt,
+        getTransactionReceiptsByBlockNumber,
         getTransactionCount,
         call,
         estimateGas,


### PR DESCRIPTION
This api due to accelerate exeplorer indexer service by batch query transation receipts.

Example on goerli testnet:
```
> eth.getTransactionReceiptsByBlockNumber("0x6e5471")
[{
    blockHash: "0x7b3d1ff3e97e1f135518ebf41ba9da351f3bedd2e019684d774d30a3ba5ddd56",
    blockNumber: "0x6e82f4",
    contractAddress: null,
    cumulativeGasUsed: "0x8b4e",
    from: "0xd05526a73bf45dadf7f9a99dcceac23c2d43c6c7",
    gasUsed: "0x8b4e",
    logs: [],
    logsBloom: "0x0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
000000000000000000000000000000",
    status: "0x0",
    to: "0xf5de760f2e916647fd766b4ad9e85ff943ce3a2b",
    transactionHash: "0x5dc80d36bb9c446025c31c68b6d828bdc16bff636c134cc4c7a85deca6280287",
    transactionIndex: "0x0"
}]
```